### PR TITLE
feat: add install link on hover in usertyle page

### DIFF
--- a/themes/userstyles/assets/scss/ui/_cards.scss
+++ b/themes/userstyles/assets/scss/ui/_cards.scss
@@ -63,4 +63,9 @@
             }
         }
     }
+    .preview-img {
+        &::after {
+            content: 'Install';
+        }
+    }
 }

--- a/themes/userstyles/layouts/styles/single.html
+++ b/themes/userstyles/layouts/styles/single.html
@@ -9,8 +9,13 @@
         <h1 class="tac">{{ .Params.name }}
             <span class="fg2"> by {{ .Params.author }}</span>
         </h1>
-        <img src="{{ .Params.preview }}"
-             alt="{{ .Params.name }} screenshot"/>
+        <div class="card col gap animate ">
+            <a href="{{ .Params.install }}">
+                <figure class="preview-img">
+                    <img src="{{ .Params.preview }}" alt="{{ .Params.install }}">
+                </figure>
+            </a>
+        </div>
         <section class="md ma">
             <h3 class="pt1">Description</h3>
             <p>{{ .Params.info }}</p>

--- a/themes/userstyles/layouts/styles/single.html
+++ b/themes/userstyles/layouts/styles/single.html
@@ -9,7 +9,7 @@
         <h1 class="tac">{{ .Params.name }}
             <span class="fg2"> by {{ .Params.author }}</span>
         </h1>
-        <div class="card col gap animate ">
+        <div class="card animate p0">
             <a href="{{ .Params.install }}">
                 <figure class="preview-img">
                     <img src="{{ .Params.preview }}" alt="{{ .Params.install }}">


### PR DESCRIPTION
I added an install link similar to the hover effect "Click to see details on the homepage" in the usertyle page. Since the we had to scroll down to find the install link and this would be a little better. I would understand if this is not what you had in mind though.